### PR TITLE
Make actions work with centered

### DIFF
--- a/addons/centered/src/components/Centered.svelte
+++ b/addons/centered/src/components/Centered.svelte
@@ -1,6 +1,6 @@
-<div class="svelte-centered-wrapper" style="{centeredStyles.style}">
-  <div class="svelte-centered-container" style="{centeredStyles.innerStyle}">
-    <svelte:component this="{OriginalComponent}" {...originalData} />
+<div class="svelte-centered-wrapper" style="{style}">
+  <div class="svelte-centered-container" style="{innerStyle}">
+    <slot></slot>
   </div>
 </div>
 
@@ -8,9 +8,8 @@
   export default {
     data() {
       return {
-        OriginalComponent: null,
-        originalData: {},
-        centeredStyles: {}
+        style: '',
+        innerStyle: ''
       };
     }
   };

--- a/addons/centered/src/svelte.js
+++ b/addons/centered/src/svelte.js
@@ -19,13 +19,7 @@ const centeredStyles = {
  * @see https://svelte.technology/guide#svelte-component
  */
 export default function(storyFn) {
-  const { Component: OriginalComponent, data: originalData } = storyFn();
+  const { Component: OriginalComponent, data, on } = storyFn();
 
-  const centeredData = {
-    OriginalComponent,
-    centeredStyles,
-    originalData,
-  };
-
-  return { Component: Centered, data: centeredData };
+  return { Component: OriginalComponent, data, on, Wrapper: Centered, WrapperData: centeredStyles };
 }

--- a/app/svelte/src/client/preview/render.js
+++ b/app/svelte/src/client/preview/render.js
@@ -7,11 +7,14 @@ function mountView({ Component, target, data, on, Wrapper, WrapperData }) {
   if (Wrapper) {
     const fragment = document.createDocumentFragment();
     component = new Component({ target: fragment, data });
-    /* eslint-disable-next-line no-new */
-    new Wrapper({
+
+    const wrapper = new Wrapper({
       target,
       slots: { default: fragment },
       data: WrapperData || {},
+    });
+    component.on('destroy', () => {
+      wrapper.destroy(true);
     });
   } else {
     component = new Component({ target, data });

--- a/app/svelte/src/client/preview/render.js
+++ b/app/svelte/src/client/preview/render.js
@@ -1,8 +1,21 @@
 import { document } from 'global';
 import { stripIndents } from 'common-tags';
 
-function mountView({ Component, target, data, on }) {
-  const component = new Component({ target, data });
+function mountView({ Component, target, data, on, Wrapper, WrapperData }) {
+  let component;
+
+  if (Wrapper) {
+    const fragment = document.createDocumentFragment();
+    component = new Component({ target: fragment, data });
+    /* eslint-disable-next-line no-new */
+    new Wrapper({
+      target,
+      slots: { default: fragment },
+      data: WrapperData || {},
+    });
+  } else {
+    component = new Component({ target, data });
+  }
 
   if (on) {
     // Attach svelte event listeners.
@@ -27,6 +40,8 @@ export default function render({
     data,
     /** @type {{[string]: () => {}}} Attach svelte event handlers */
     on,
+    Wrapper,
+    WrapperData,
   } = story();
 
   const target = document.getElementById('root');
@@ -46,7 +61,7 @@ export default function render({
     return;
   }
 
-  mountView({ Component, target, data, on });
+  mountView({ Component, target, data, on, Wrapper, WrapperData });
 
   showMain();
 }


### PR DESCRIPTION
`Actions` addon does not work with `Centered` addon.
This is because events are not passed through to the inner component.

This PR fixes that by keeping a reference to the original component and attaching the event handlers to the original component.
It then mounts the original component into a `slot` of the wrapper component provided by the `Centered` addon.

This approach makes it trivial to implement other addons that might need to wrap the original component in this way.

I have tested this as much as possible, but please do check from your side too.

I think if you merge this PR to this branch, it will get added to the PR on the storybooks repo.
